### PR TITLE
removed section on patent rights

### DIFF
--- a/DEP Template.md
+++ b/DEP Template.md
@@ -101,10 +101,6 @@ Write tests that could be run under an implementation to determine if it impleme
 
 Imagine an adversary is going to write a malicious implementation of your proposal that passes its tests but otherwise does things so horrible it will cause the language team to run screaming from your proposal. Don't let the adversary win.
 
-## Patents rights
-
-TC52, the Ecma technical committee working on evolving the open [Dart standard][], operates under a royalty-free patent policy, [RFPP][] (PDF). This means if the proposal graduates to being sent to TC52, you will have to sign the Ecma TC52 [external contributer form][] and submit it to Ecma.
-
 [tex]: http://www.latex-project.org/
 [language spec]: https://www.dartlang.org/docs/spec/
 [dart standard]: http://www.ecma-international.org/publications/standards/Ecma-408.htm

--- a/DEP Template.md
+++ b/DEP Template.md
@@ -104,5 +104,4 @@ Imagine an adversary is going to write a malicious implementation of your propos
 [tex]: http://www.latex-project.org/
 [language spec]: https://www.dartlang.org/docs/spec/
 [dart standard]: http://www.ecma-international.org/publications/standards/Ecma-408.htm
-[rfpp]: http://www.ecma-international.org/memento/TC52%20policy/Ecma%20Experimental%20TC52%20Royalty-Free%20Patent%20Policy.pdf
 [external contributer form]: http://www.ecma-international.org/memento/TC52%20policy/Contribution%20form%20to%20TC52%20Royalty%20Free%20Task%20Group%20as%20a%20non-member.pdf


### PR DESCRIPTION
As this section is more "instructions" rather than actual template content that should go into the DEP itself, I've moved this to the instructions / walk through part.